### PR TITLE
[Refactor/#9] 이메일 인증 처리 및 회원가입 시 인증 여부 확인

### DIFF
--- a/msa-iamhere-member/build.gradle
+++ b/msa-iamhere-member/build.gradle
@@ -13,6 +13,9 @@ repositories {
 }
 
 dependencies {
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     implementation 'mysql:mysql-connector-java:8.0.27'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
@@ -25,6 +28,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.0.2'
     implementation 'javax.servlet:javax.servlet-api:4.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-logging:3.1.0'
     testImplementation 'org.springframework.security:spring-security-test:6.0.0'
 }
 

--- a/msa-iamhere-member/src/main/java/com/personal/member/config/SessionListener.java
+++ b/msa-iamhere-member/src/main/java/com/personal/member/config/SessionListener.java
@@ -1,0 +1,25 @@
+package com.personal.member.config;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+@Component
+public class SessionListener implements HttpSessionListener {
+    @Override
+    public void sessionDestroyed(HttpSessionEvent event){
+        HttpSession session = event.getSession();
+
+        if(session.getAttribute("mailVerified")!= null && session.getAttribute("userMail")!= null){
+            boolean mailVerified = (boolean) session.getAttribute("mailVerified");
+            String userMail = (String) session.getAttribute("userMail");
+            if(mailVerified){
+                session.invalidate();
+                session.setAttribute("mailVerified", mailVerified);
+                session.setAttribute("userMail", userMail);
+            }
+        }
+    }
+}

--- a/msa-iamhere-member/src/main/java/com/personal/member/controller/MemberController.java
+++ b/msa-iamhere-member/src/main/java/com/personal/member/controller/MemberController.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
@@ -17,16 +21,34 @@ public class MemberController {
 
     private final MailService mailService;
 
+    private final HttpSession session;
+
     @PostMapping("/join")
-    public ResponseEntity<Member> insertMember(@RequestBody MemberDTO memberDTO) throws Exception {
-        return ResponseEntity.ok(memberService.insertMember(memberDTO));
+    public ResponseEntity<Member> join(@RequestBody MemberDTO memberDTO) throws Exception {
+        return ResponseEntity.ok(memberService.join(memberDTO));
     }
 
     @PostMapping("/join/confirm")
     @ResponseBody
-    public ResponseEntity<String> confirmMail(@RequestParam("mail") String mail) throws Exception {
+    public ResponseEntity<String> confirmMail(@RequestParam("mail") String mail, HttpServletResponse response) throws Exception {
         String code = mailService.sendSimpleMessage(mail);
+        Cookie verificationCookie = new Cookie("verificationCode", code);
+        verificationCookie.setMaxAge(180);
+        response.addCookie(verificationCookie);
         return ResponseEntity.ok(code);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Boolean> verifyMail(@RequestParam("verificationCode") String verificationCode,
+                                              @RequestParam("mail") String mail,
+                                              @CookieValue(value = "verificationCode") String storedVerificationCode) {
+        boolean isVerified = false;
+        if (verificationCode.equals(storedVerificationCode)){
+            isVerified = true;
+            session.setAttribute("mailVerified", true);
+            session.setAttribute("userMail", mail);
+        }
+        return ResponseEntity.ok(isVerified);
     }
 
     @PostMapping("/login")

--- a/msa-iamhere-member/src/main/java/com/personal/member/controller/MemberController.java
+++ b/msa-iamhere-member/src/main/java/com/personal/member/controller/MemberController.java
@@ -1,11 +1,11 @@
 package com.personal.member.controller;
 
-import com.personal.member.domain.Member;
 import com.personal.member.dto.LoginDTO;
 import com.personal.member.dto.MemberDTO;
 import com.personal.member.service.MailService;
 import com.personal.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +15,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
@@ -25,6 +27,8 @@ public class MemberController {
 
     private final HttpServletRequest request;
 
+    private final HttpServletResponse response;
+
     @PostMapping("/join")
     public ResponseEntity<?> join(@RequestBody MemberDTO memberDTO, @SessionAttribute(name = "mailVerified", required = false) Boolean mailVerified) throws Exception {
         if(mailVerified == null || !mailVerified)
@@ -34,7 +38,7 @@ public class MemberController {
 
     @PostMapping("/join/confirm")
     @ResponseBody
-    public ResponseEntity<String> confirmMail(@RequestParam("mail") String mail, HttpServletResponse response) throws Exception {
+    public ResponseEntity<String> confirmMail(@RequestParam("mail") String mail) throws Exception {
         String code = mailService.sendSimpleMessage(mail);
         Cookie verificationCookie = new Cookie("verificationCode", code);
         verificationCookie.setMaxAge(180);

--- a/msa-iamhere-member/src/main/java/com/personal/member/service/MailServiceImpl.java
+++ b/msa-iamhere-member/src/main/java/com/personal/member/service/MailServiceImpl.java
@@ -12,7 +12,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Random;
 
 @Service
-public class RegisterMail implements MailService {
+public class MailServiceImpl implements MailService {
 
     @Autowired
     private JavaMailSender emailSender;

--- a/msa-iamhere-member/src/main/java/com/personal/member/service/MemberService.java
+++ b/msa-iamhere-member/src/main/java/com/personal/member/service/MemberService.java
@@ -10,7 +10,6 @@ import com.personal.member.utils.JwtTokenUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -25,7 +24,7 @@ public class MemberService {
     private String key;
     private Long expireTimeMs = 1000 * 60 * 60L;
 
-    public Member insertMember(MemberDTO memberDTO) {
+    public Member join(MemberDTO memberDTO) {
         if (this.isEmailExists(memberDTO.getMail())) {
             throw new AppException(ErrorCode.MAIL_DUPLICATED);
         }

--- a/msa-iamhere-member/src/test/java/com/personal/member/controller/MemberControllerTest.java
+++ b/msa-iamhere-member/src/test/java/com/personal/member/controller/MemberControllerTest.java
@@ -1,7 +1,6 @@
 package com.personal.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.personal.member.domain.Member;
 import com.personal.member.dto.LoginDTO;
 import com.personal.member.dto.MemberDTO;
 import com.personal.member.exception.AppException;
@@ -62,7 +61,7 @@ class MemberControllerTest {
     void insertMember() throws Exception {
         // given
         MemberDTO memberDTO = new MemberDTO("gms08194@gmail.com", "asdf1234", new Date(2023 - 01 - 02));
-        when(memberService.insertMember(any(MemberDTO.class))).thenReturn(memberDTO.toEntity());
+        when(memberService.join(any(MemberDTO.class))).thenReturn(memberDTO.toEntity());
 
         // when
         mockMvc.perform(post("/api/v1/members/join")
@@ -78,7 +77,7 @@ class MemberControllerTest {
     public void insertMember_fail() throws Exception {
         // given
         MemberDTO memberDTO = new MemberDTO("gms08194@gmail.com", "asdf1234", new Date(2023 - 01 - 02));
-        when(memberService.insertMember(any(MemberDTO.class))).thenThrow(new RuntimeException("he mail is already exist!"));
+        when(memberService.join(any(MemberDTO.class))).thenThrow(new RuntimeException("he mail is already exist!"));
 
         // when
         mockMvc.perform(post("/api/v1/members/join")

--- a/msa-iamhere-member/src/test/java/com/personal/member/controller/MemberControllerTest.java
+++ b/msa-iamhere-member/src/test/java/com/personal/member/controller/MemberControllerTest.java
@@ -7,30 +7,40 @@ import com.personal.member.exception.AppException;
 import com.personal.member.exception.ErrorCode;
 import com.personal.member.service.MailService;
 import com.personal.member.service.MemberService;
+import jakarta.servlet.http.Cookie;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
+@Slf4j
+@AutoConfigureMockMvc
 @WebMvcTest(MemberController.class)
 class MemberControllerTest {
 
@@ -50,6 +60,9 @@ class MemberControllerTest {
 
     @MockBean
     private HttpServletRequest request;
+
+    @MockBean
+    private HttpServletResponse response;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -114,12 +127,11 @@ class MemberControllerTest {
     @DisplayName("인증메일을 정상적으로 발송한다.")
     @Test
     void sendMail() throws Exception {
-        String to = "gms08194@gmail.com";
-        String key = "3pqb9qKf";
-        when(mailService.sendSimpleMessage(to)).thenReturn(key);
+        String to = "mingyum119@gmail.com";
+        String key = "3pqb9qKs";
+        when(mailService.sendSimpleMessage(anyString())).thenReturn(key);
 
-        // when
-        mockMvc.perform(post("/api/v1/members/join/confirm")
+         mockMvc.perform(post("/api/v1/members/join/confirm")
                         .with(csrf())
                         .param("mail", to))
                 .andExpect(status().isOk())

--- a/msa-iamhere-member/src/test/java/com/personal/member/service/MemberServiceTest.java
+++ b/msa-iamhere-member/src/test/java/com/personal/member/service/MemberServiceTest.java
@@ -60,7 +60,7 @@ class MemberServiceTest {
         when(memberRepository.findByMail(any(String.class))).thenReturn(Optional.empty());
 
         // when
-        Member member =  memberService.insertMember(memberDTO);
+        Member member =  memberService.join(memberDTO);
 
         // then
         assertEquals(member.getPassword(), encoded);


### PR DESCRIPTION
## ⭐ 기능 설명
(1) 이메일로 전송 받은 인증 번호를 서버에 내에 쿠키로 저장한다. 
(2) 사용자가 값을 입력하면 유효성 검사를 진행한다.
(3) 이메일이 인증 완료되었다는 정보를 세션에 저장한다. 
(4) 세션을 활용해 회원가입 시 인증이 완료되었는 지 여부를 확인한다.

## 😎 작업 내용
* MemberController에 `veritfyMail` 함수 추가
* MemberController의 join 함수에 세션이 있는 지, 있다면 true의 값을 가지는 지 확인하는 로직 추가
* SessoinListener, 세션이 종료되어 이메일 인증 완료 정보가 파기되는 것을 방지하여 세션 재발급 로직 추가

## 🌈 추가 검토할 사항

인증메일을 발송하는 테스트 코드에서 `409` 에러가 뜬다. 

예상 원인 
- 쿠키 이름의 중복 (X) : 쿠키에서 이름은 중복가능하지 않으나, 이미 존재하는 쿠키가 들어왔을 때 값을 자동으로 갱신한다.
- CSRF (X)  : `with(csrf())` 구문을 mockMvc로 API를 호출하는 부분에 넣으면 해결된다.
- 메일 주소의 중복 (X) : 메일 주소의 중복체크는 수행하지 않았다.
- `HttpServletResponse` 매개변수를 넣지 않은 것 (O) : 테스트를 통해 `HttpServletResponse`를 매개변수에 넣은 것이 문제라는 결론이 나왔다. 그래서 Controller에서 지역 변수로 주입하였던 response 객체를 전역변수로 변경하여 테스트하여 해결하였다.